### PR TITLE
Fix roff Wikipedia link

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Copyright (c) 2013-2023 Hal Brodigan
 See {file:LICENSE.txt} for details.
 
 [kramdown]: http://kramdown.gettalong.org/
-[roff]: https://en.wikipedia.org/wiki/Roff_(software)
+[roff]: http://en.wikipedia.org/wiki/Roff_(software)
 
 [Ruby]: http://www.ruby-lang.org/
 [JRuby]: http://jruby.org/

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Copyright (c) 2013-2023 Hal Brodigan
 See {file:LICENSE.txt} for details.
 
 [kramdown]: http://kramdown.gettalong.org/
-[roff]: http://en.wikipedia.org/wiki/Roff_(software)
+[roff]: https://en.wikipedia.org/wiki/Roff_(software)
 
 [Ruby]: http://www.ruby-lang.org/
 [JRuby]: http://jruby.org/

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Copyright (c) 2013-2023 Hal Brodigan
 See {file:LICENSE.txt} for details.
 
 [kramdown]: http://kramdown.gettalong.org/
-[roff]: http://en.wikipedia.org/wiki/Roff
+[roff]: https://en.wikipedia.org/wiki/Roff_(software)
 
 [Ruby]: http://www.ruby-lang.org/
 [JRuby]: http://jruby.org/


### PR DESCRIPTION
Updates the Wikipedia link to go to the actual Roff page, rather than the disambiguation page on wikipedia